### PR TITLE
Add async method to truncate shapes in IBulkShapeRepository

### DIFF
--- a/Repositories/Bulk/Transit/IBulkShapeRepository.cs
+++ b/Repositories/Bulk/Transit/IBulkShapeRepository.cs
@@ -7,4 +7,5 @@ namespace Mtd.Stopwatch.Core.Repositories.Bulk.Transit;
 public interface IBulkShapeRepository<T_Collection> : IShapeRepository<T_Collection>, IAsyncBulkWriteable<Shape, T_Collection>
 	where T_Collection : IEnumerable<Shape>
 {
+	Task TruncateShapesAndShapePointsAsync(CancellationToken cancellationToken);
 }


### PR DESCRIPTION
A new method `TruncateShapesAndShapePointsAsync` has been added to the `IBulkShapeRepository` interface. This method is asynchronous and takes a `CancellationToken` as a parameter. It is intended to truncate shapes and shape points.